### PR TITLE
Javadoc fix

### DIFF
--- a/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/api/worker/WorkflowApiController.java
+++ b/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/api/worker/WorkflowApiController.java
@@ -1,7 +1,7 @@
 /**
  * File:     WorkflowApiController.java
  * Package:  de.uniwuerzburg.zpd.ocr4all.application.api.worker
- * 
+ *
  * Author:   Herbert Baier (herbert.baier@uni-wuerzburg.de)
  * Date:     17.04.2023
  */
@@ -68,9 +68,10 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Creates a workflow controller for the api.
-	 * 
+	 *
 	 * @param configurationService The configuration service.
 	 * @param securityService      The security service.
+	 * @param schedulerService     The scheduler service.
 	 * @param service              The workflow service.
 	 * @param projectService       The project service.
 	 * @param sandboxService       The sandbox service.
@@ -87,7 +88,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Returns the workflow core data in the response body.
-	 * 
+	 *
 	 * @param workflowId The workflow id.
 	 * @return The workflow core data in the response body.
 	 * @since 1.8
@@ -107,7 +108,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Returns the metadata of the workflows in the response body.
-	 * 
+	 *
 	 * @return The metadata of the workflows in the response body.
 	 * @since 1.8
 	 */
@@ -126,7 +127,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Creates the workflow and returns its metadata in the response body.
-	 * 
+	 *
 	 * @param request The workflow request.
 	 * @return The metadata in the response body.
 	 * @since 1.8
@@ -151,7 +152,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Updates the workflow and returns its metadata in the response body.
-	 * 
+	 *
 	 * @param workflowId The workflow id.
 	 * @param request    The workflow request.
 	 * @return The updated metadata in the response body.
@@ -177,7 +178,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Returns the metadata of the workflows in the response body.
-	 * 
+	 *
 	 * @param workflowId The workflow id.
 	 * @param response   The HTTP-specific functionality in sending a response to
 	 *                   the client.
@@ -199,7 +200,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Returns true if the workflow is available.
-	 * 
+	 *
 	 * @param project The project.
 	 * @param sandbox The sandbox.
 	 * @return True if the workflow is available.
@@ -220,7 +221,7 @@ public class WorkflowApiController extends CoreApiController {
 
 	/**
 	 * Schedules a process to execute the workflow.
-	 * 
+	 *
 	 * @param projectId  The project id. This is the folder name.
 	 * @param sandboxId  The sandbox id. This is the folder name.
 	 * @param workflowId The workflow id.

--- a/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/core/job/Workflow.java
+++ b/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/core/job/Workflow.java
@@ -1,7 +1,7 @@
 /**
  * File:     Workflow.java
  * Package:  de.uniwuerzburg.zpd.ocr4all.application.core.job
- * 
+ *
  * Author:   Herbert Baier (herbert.baier@uni-wuerzburg.de)
  * Date:     24.04.2023
  */
@@ -60,7 +60,7 @@ public class Workflow extends Process {
 
 	/**
 	 * Creates a workflow.
-	 * 
+	 *
 	 * @param configurationService The configuration service.
 	 * @param locale               The application locale.
 	 * @param processing           The processing mode.
@@ -108,7 +108,7 @@ public class Workflow extends Process {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see de.uniwuerzburg.zpd.ocr4all.application.core.job.Job#getTargetName()
 	 */
 	@Override
@@ -118,7 +118,7 @@ public class Workflow extends Process {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * de.uniwuerzburg.zpd.ocr4all.application.core.job.Job#getShortDescription()
 	 */
@@ -132,7 +132,7 @@ public class Workflow extends Process {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see de.uniwuerzburg.zpd.ocr4all.application.core.job.Job#execute()
 	 */
 	@Override
@@ -142,7 +142,7 @@ public class Workflow extends Process {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see de.uniwuerzburg.zpd.ocr4all.application.core.job.Job#kill()
 	 */
 	@Override
@@ -156,7 +156,7 @@ public class Workflow extends Process {
 
 	/**
 	 * Returns true if the path reaches its target, this means, it has no children.
-	 * 
+	 *
 	 * @param path The path.
 	 * @return True if the path reaches its target.
 	 * @since 1.8
@@ -172,7 +172,7 @@ public class Workflow extends Process {
 
 	/**
 	 * Executes the workflow defined in the paths using depth-first search.
-	 * 
+	 *
 	 * @param parentSnapshot The parent snapshot.
 	 * @param paths          The paths.
 	 * @param step           The current step.
@@ -255,8 +255,8 @@ public class Workflow extends Process {
 
 		/**
 		 * Creates a workflow provider.
-		 * 
-		 * @param provider     The service provider.
+		 *
+		 * @param serviceProvider     The service provider.
 		 * @param snapshotType The snapshot type.
 		 * @since 1.8
 		 */

--- a/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/core/job/Workflow.java
+++ b/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/core/job/Workflow.java
@@ -256,8 +256,9 @@ public class Workflow extends Process {
 		/**
 		 * Creates a workflow provider.
 		 *
-		 * @param serviceProvider     The service provider.
-		 * @param snapshotType The snapshot type.
+		 * @param serviceProvider  The service provider.
+		 * @param snapshotType     The snapshot type.
+		 * @param processor        The processor.
 		 * @since 1.8
 		 */
 		public Provider(ProcessServiceProvider serviceProvider, Type snapshotType, Processor processor) {


### PR DESCRIPTION
The latest commit of the `feature/job_workflow` leads to one javadoc build error and two warnings. The commits included in this PR fix these errors and warnings but either renaming `@param` annotations or adding them.